### PR TITLE
Grant sufficient GitHub token permissions for dependabot.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ on: push
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes broken builds, e.g. https://github.com/theipster/html-video-recorder/actions/runs/4776444955/attempts/1